### PR TITLE
Bug with base64urlencode string replacing

### DIFF
--- a/src/jwt-token.js
+++ b/src/jwt-token.js
@@ -45,8 +45,8 @@ var JWTInternals = (function() {
   {
     var s = window.btoa(arg); // Standard base64 encoder
     s = s.split('=')[0]; // Remove any trailing '='s
-    s = s.replace('+', '-', 'g'); // 62nd char of encoding
-    s = s.replace('/', '_', 'g'); // 63rd char of encoding
+    s = s.replace(/\+/g, '-'); // 62nd char of encoding
+    s = s.replace(/\//g, '_'); // 63rd char of encoding
     // TODO optimize this; we can do much better
     return s;
   }
@@ -54,8 +54,8 @@ var JWTInternals = (function() {
   function base64urldecode(arg)
   {
     var s = arg;
-    s = s.replace('-', '+', 'g'); // 62nd char of encoding
-    s = s.replace('_', '/', 'g'); // 63rd char of encoding
+    s = s.replace(/-/g, '+'); // 62nd char of encoding
+    s = s.replace(/_/g, '/'); // 63rd char of encoding
     switch (s.length % 4) // Pad with trailing '='s
     {
       case 0: break; // No pad chars in this case


### PR DESCRIPTION
I had a weird error in my application that happened very rarely, but it bugged me enough to spend time solving it. I was hunting this bug for days until I finally found out that the problem occurred when the signature part of the serialized WebToken had more than one plus signs in it.

The current implementation of the `base64urlencode` is using a non-standard method for replacing "global" string occurrence, which doesn't seem to work with some of the modern browsers (ie. WebKit based). This resulted in a behavior that only the first occurrence of the plus sign got replaced to a dash, but not the rest. And when the end result was used in the URL, the plus signs got decoded into spaces and that's where the signature failed.

I changed the `base64urlencode` and `base64urldecode` to use a proper regular expression in the replace method, which has a more standard way of matching global patterns.
